### PR TITLE
Switch icon back to default on user logout.

### DIFF
--- a/GitSwitch/CustomApplicationContext.cs
+++ b/GitSwitch/CustomApplicationContext.cs
@@ -13,6 +13,7 @@ namespace GitSwitch
         private EditUsersForm editUsersForm;
         private HelpForm helpForm;
         private IconRepository iconRepository;
+        private Icon defaultIcon;
 
         public CustomApplicationContext()
         {
@@ -25,10 +26,11 @@ namespace GitSwitch
 
         private void InitializeTrayIcon()
         {
+            defaultIcon = new Icon("gitswitch64x64.ico");
             notifyIcon = new NotifyIcon()
             {
                 ContextMenuStrip = new ContextMenuStrip(),
-                Icon = new Icon("gitswitch64x64.ico"),
+                Icon = defaultIcon,
                 Text = "GitSwitch",
                 Visible = true
             };
@@ -131,6 +133,7 @@ namespace GitSwitch
         private void OnLogout(object sender, EventArgs e)
         {
             gitUserManager.ConfigureForUser("");
+            notifyIcon.Icon = defaultIcon;
         }
 
         private void OnHelp(object sender, EventArgs e)

--- a/GitSwitch/Properties/AssemblyInfo.cs
+++ b/GitSwitch/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4.0.0")]
-[assembly: AssemblyFileVersion("1.4.0.0")]
-[assembly: AssemblyInformationalVersion("1.4.0.0")]
+[assembly: AssemblyVersion("1.5.0.0")]
+[assembly: AssemblyFileVersion("1.5.0.0")]
+[assembly: AssemblyInformationalVersion("1.5.0.0")]


### PR DESCRIPTION
Previous to this commit, the notification icon would keep the user's gravatar after logout.
